### PR TITLE
Convert "acceptable in the process of dev" errors to warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": "shopify/es5",
+  "rules": {
+    // For consistency with keys that require quotes
+    "quote-props": 0
+  }
+}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ For changes to existing rules, bump the major version. For addition of new rules
 
 ## Changelog
 
+### 5.5.0
+
+Converts most rules to being warnings rather than errors. Rules that catch existing bugs or *extremely* bad practices are still treated as errors.
+
 ### 5.4.0
 
 Adds the new rules from `eslint-plugin-shopify`.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For changes to existing rules, bump the major version. For addition of new rules
 
 ### 5.5.0
 
-Converts most rules to being warnings rather than errors. Rules that catch existing bugs or *extremely* bad practices are still treated as errors.
+Converts most rules to being warnings rather than errors. Rules that catch existing bugs or that are considered bad practices are still treated as errors.
 
 ### 5.4.0
 

--- a/core/index.js
+++ b/core/index.js
@@ -1,12 +1,17 @@
-var merge = require("merge");
+var merge = require('merge');
 
 module.exports = {
+  plugins: [
+    'shopify',
+  ],
+
   rules: merge(
-    require("../rules/best-practices"),
-    require("../rules/legacy"),
-    require("../rules/possible-errors"),
-    require("../rules/strict-mode"),
-    require("../rules/stylistic-issues"),
-    require("../rules/variables")
-  )
+    require('../rules/best-practices'),
+    require('../rules/legacy'),
+    require('../rules/possible-errors'),
+    require('../rules/shopify'),
+    require('../rules/strict-mode'),
+    require('../rules/stylistic-issues'),
+    require('../rules/variables')
+  ),
 };

--- a/es5/index.js
+++ b/es5/index.js
@@ -1,14 +1,14 @@
-var merge = require("merge");
+var merge = require('merge');
 
 module.exports = {
-  extends: "shopify/core",
+  extends: 'shopify/core',
 
-  plugins: [
-    "shopify"
-  ],
+  env: {
+    node: true,
+  },
 
   rules: merge(
-    require("../rules/node"),
-    require("../rules/shopify")
-  )
+    require('../rules/node'),
+    {'shopify/require-flow': 0}
+  ),
 };

--- a/es6/index.js
+++ b/es6/index.js
@@ -1,25 +1,20 @@
-var merge = require("merge")
+var merge = require('merge');
 
 module.exports = {
-  extends: "shopify/core",
-  parser: "babel-eslint",
-
-  plugins: [
-    "shopify"
-  ],
+  extends: 'shopify/core',
+  parser: 'babel-eslint',
 
   env: {
     es6: true,
-    node: true
+    node: true,
   },
 
   ecmaFeatures: {
-    modules: true
+    modules: true,
   },
 
   rules: merge(
-    require("../rules/ecmascript-6"),
-    require("../rules/shopify"),
-    {"no-param-reassign": 0} // because of default params
-  )
+    require('../rules/ecmascript-6'),
+    {'no-param-reassign': 0} // because of default params
+  ),
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/shopify/eslint-config-shopify"
   },
+  "scripts": {
+    "lint": "node_modules/.bin/eslint ."
+  },
   "keywords": [
     "eslint",
     "eslintconfig",
@@ -27,7 +30,10 @@
   },
   "devDependencies": {
     "babel-eslint": "^4.1.2",
-    "eslint": "^1.4.1"
+    "eslint": "^1.4.1",
+    "eslint-config-shopify": "file:.",
+    "eslint-plugin-react": "^3.5.0",
+    "eslint-plugin-shopify": "^2.0.0"
   },
   "peerDependencies": {
     "eslint": ">=1.5.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "eslint": "^1.4.1"
   },
   "peerDependencies": {
-    "eslint": ">=1.5.0"
+    "eslint": ">=1.5.0",
+    "eslint-plugin-react": "^3.5.0",
+    "eslint-plugin-shopify": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-shopify",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "Shopify's baseline ESLint config.",
   "main": "./es6/index.js",
   "repository": {

--- a/react/index.js
+++ b/react/index.js
@@ -1,20 +1,20 @@
 module.exports = {
-  extends: "shopify/es6",
+  extends: 'shopify/es6',
 
   plugins: [
-    "react",
-    "shopify"
+    'react',
+    'shopify',
   ],
 
   ecmaFeatures: {
-    jsx: true
+    jsx: true,
   },
 
   globals: {
     fetch: true,
     ReactElement: true,
-    ReactClass: true
+    ReactClass: true,
   },
 
-  rules: require("../rules/react")
+  rules: require('../rules/react'),
 };

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -2,114 +2,114 @@
 
 module.exports = {
   // Enforces getter/setter pairs in objects (off by default)
-  "accessor-pairs": 0,
+  'accessor-pairs': 0,
   // Treat var statements as if they were block scoped (off by default)
-  "block-scoped-var": 1,
+  'block-scoped-var': 1,
   // Specify the maximum cyclomatic complexity allowed in a program (off by default)
-  "complexity": 0,
+  'complexity': 0,
   // Require return statements to either always or never specify values
-  "consistent-return": 1,
+  'consistent-return': 1,
   // Specify curly brace conventions for all control statements
-  "curly": [1, "all"],
+  'curly': [1, 'all'],
   // Require default case in switch statements (off by default)
-  "default-case": 0,
+  'default-case': 0,
   // Encourages use of dot notation whenever possible
-  "dot-notation": [1, { allowKeywords: true }],
+  'dot-notation': [1, {allowKeywords: true}],
   // Enforces consistent newlines before or after dots (off by default)
-  "dot-location": [1, "property"],
+  'dot-location': [1, 'property'],
   // Require the use of === and !==
-  "eqeqeq": [2, "allow-null"],
+  'eqeqeq': [2, 'allow-null'],
   // Make sure for-in loops have an if statement (off by default)
-  "guard-for-in": 1,
+  'guard-for-in': 1,
   // Disallow the use of alert, confirm, and prompt
-  "no-alert": 1,
+  'no-alert': 1,
   // Disallow use of arguments.caller or arguments.callee
-  "no-caller": 2,
+  'no-caller': 2,
   // Disallow division operators explicitly at beginning of regular expression (off by default)
-  "no-div-regex": 1,
+  'no-div-regex': 1,
   // Disallow else after a return in an if (off by default)
-  "no-else-return": 0,
+  'no-else-return': 0,
   // Disallow use of labels for anything other than loops and switches
-  "no-empty-label": 2,
+  'no-empty-label': 2,
   // Disallow comparisons to null without a type-checking operator (off by default)
-  "no-eq-null": 0,
+  'no-eq-null': 0,
   // Disallow use of eval()
-  "no-eval": 2,
+  'no-eval': 2,
   // Disallow adding to native types
-  "no-extend-native": 2,
+  'no-extend-native': 2,
   // Disallow unnecessary function binding
-  "no-extra-bind": 1,
+  'no-extra-bind': 1,
   // Disallow fallthrough of case statements
-  "no-fallthrough": 2,
+  'no-fallthrough': 2,
   // Disallow the use of leading or trailing decimal points in numeric literals (off by default)
-  "no-floating-decimal": 1,
+  'no-floating-decimal': 1,
   // Disallow the type conversions with shorter notations
-  "no-implicit-coercion": 1,
+  'no-implicit-coercion': 1,
   // Disallow use of eval()-like methods
-  "no-implied-eval": 2,
+  'no-implied-eval': 2,
   // Disallow this keywords outside of classes or class-like objects
-  "no-invalid-this": 0,
+  'no-invalid-this': 0,
   // Disallow usage of __iterator__ property
-  "no-iterator": 2,
+  'no-iterator': 2,
   // Disallow use of labeled statements
-  "no-labels": 2,
+  'no-labels': 2,
   // Disallow unnecessary nested blocks
-  "no-lone-blocks": 1,
+  'no-lone-blocks': 1,
   // Disallow creation of functions within loops
-  "no-loop-func": 2,
+  'no-loop-func': 2,
   // Disallow use of multiple spaces
-  "no-multi-spaces": 1,
+  'no-multi-spaces': 1,
   // Disallow use of multiline strings
-  "no-multi-str": 0,
+  'no-multi-str': 0,
   // Disallow reassignments of native objects
-  "no-native-reassign": 2,
+  'no-native-reassign': 2,
   // Disallow use of new operator for Function object
-  "no-new-func": 2,
+  'no-new-func': 2,
   // Disallows creating new instances of String, Number, and Boolean
-  "no-new-wrappers": 2,
+  'no-new-wrappers': 2,
   // Disallow use of new operator when not part of the assignment or comparison
-  "no-new": 1,
+  'no-new': 1,
   // Disallow use of octal escape sequences in string literals,
   // such as var foo = "Copyright \251";
-  "no-octal-escape": 2,
+  'no-octal-escape': 2,
   // Disallow use of octal literals
-  "no-octal": 1,
+  'no-octal': 1,
   // Allow reassignment of function parameters (off by default)
-  "no-param-reassign": 0,
+  'no-param-reassign': 0,
   // Disallow use of process.env (off by default)
-  "no-process-env": 2,
+  'no-process-env': 2,
   // Disallow usage of __proto__ property
-  "no-proto": 2,
+  'no-proto': 2,
   // Disallow declaring the same variable more than once
-  "no-redeclare": 2,
+  'no-redeclare': 2,
   // Disallow use of assignment in return statement
-  "no-return-assign": 2,
+  'no-return-assign': 2,
   // Disallow use of javascript: urls.,
-  "no-script-url": 0,
+  'no-script-url': 0,
   // Disallow comparisons where both sides are exactly the same (off by default)
-  "no-self-compare": 2,
+  'no-self-compare': 2,
   // Disallow use of comma operator
-  "no-sequences": 1,
+  'no-sequences': 1,
   // Restrict what can be thrown as an exception (off by default)
-  "no-throw-literal": 1,
+  'no-throw-literal': 1,
   // Allow usage of expressions in statement position
-  "no-unused-expressions": 1,
+  'no-unused-expressions': 1,
   // Disallow unnecessary .call() and .apply()
-  "no-useless-call": 2,
+  'no-useless-call': 2,
   // Disallow unnecessary concatenation of literals or template literals
-  "no-useless-concat": 1,
+  'no-useless-concat': 1,
   // Disallow use of void operator (off by default)
-  "no-void": 2,
+  'no-void': 2,
   // Disallow usage of configurable warning terms in comments
-  "no-warning-comments": 1,
+  'no-warning-comments': 1,
   // Disallow use of the with statement
-  "no-with": 2,
+  'no-with': 2,
   // Require use of the second argument for parseInt() (off by default)
-  "radix": 2,
+  'radix': 2,
   // Requires to declare all vars on top of their containing scope (off by default)
-  "vars-on-top": 0,
+  'vars-on-top': 0,
   // Require immediate function invocation to be wrapped in parentheses (off by default)
-  "wrap-iife": [1, "inside"],
+  'wrap-iife': [1, 'inside'],
   // Require or disallow Yoda conditions
-  "yoda": [1, "never"]
-}
+  'yoda': [1, 'never'],
+};

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -18,7 +18,7 @@ module.exports = {
   // Enforces consistent newlines before or after dots (off by default)
   "dot-location": [1, "property"],
   // Require the use of === and !==
-  "eqeqeq": [1, "allow-null"],
+  "eqeqeq": [2, "allow-null"],
   // Make sure for-in loops have an if statement (off by default)
   "guard-for-in": 1,
   // Disallow the use of alert, confirm, and prompt
@@ -36,11 +36,11 @@ module.exports = {
   // Disallow use of eval()
   "no-eval": 2,
   // Disallow adding to native types
-  "no-extend-native": 1,
+  "no-extend-native": 2,
   // Disallow unnecessary function binding
   "no-extra-bind": 1,
   // Disallow fallthrough of case statements
-  "no-fallthrough": 1,
+  "no-fallthrough": 2,
   // Disallow the use of leading or trailing decimal points in numeric literals (off by default)
   "no-floating-decimal": 1,
   // Disallow the type conversions with shorter notations
@@ -56,7 +56,7 @@ module.exports = {
   // Disallow unnecessary nested blocks
   "no-lone-blocks": 1,
   // Disallow creation of functions within loops
-  "no-loop-func": 1,
+  "no-loop-func": 2,
   // Disallow use of multiple spaces
   "no-multi-spaces": 1,
   // Disallow use of multiline strings
@@ -66,24 +66,24 @@ module.exports = {
   // Disallow use of new operator for Function object
   "no-new-func": 2,
   // Disallows creating new instances of String, Number, and Boolean
-  "no-new-wrappers": 1,
+  "no-new-wrappers": 2,
   // Disallow use of new operator when not part of the assignment or comparison
   "no-new": 1,
   // Disallow use of octal escape sequences in string literals,
   // such as var foo = "Copyright \251";
-  "no-octal-escape": 1,
+  "no-octal-escape": 2,
   // Disallow use of octal literals
   "no-octal": 1,
   // Allow reassignment of function parameters (off by default)
   "no-param-reassign": 0,
   // Disallow use of process.env (off by default)
-  "no-process-env": 1,
+  "no-process-env": 2,
   // Disallow usage of __proto__ property
   "no-proto": 2,
   // Disallow declaring the same variable more than once
-  "no-redeclare": 1,
+  "no-redeclare": 2,
   // Disallow use of assignment in return statement
-  "no-return-assign": 1,
+  "no-return-assign": 2,
   // Disallow use of javascript: urls.,
   "no-script-url": 0,
   // Disallow comparisons where both sides are exactly the same (off by default)
@@ -95,11 +95,11 @@ module.exports = {
   // Allow usage of expressions in statement position
   "no-unused-expressions": 1,
   // Disallow unnecessary .call() and .apply()
-  "no-useless-call": 1,
+  "no-useless-call": 2,
   // Disallow unnecessary concatenation of literals or template literals
   "no-useless-concat": 1,
   // Disallow use of void operator (off by default)
-  "no-void": 1,
+  "no-void": 2,
   // Disallow usage of configurable warning terms in comments
   "no-warning-comments": 1,
   // Disallow use of the with statement

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -4,29 +4,29 @@ module.exports = {
   // Enforces getter/setter pairs in objects (off by default)
   "accessor-pairs": 0,
   // Treat var statements as if they were block scoped (off by default)
-  "block-scoped-var": 2,
+  "block-scoped-var": 1,
   // Specify the maximum cyclomatic complexity allowed in a program (off by default)
   "complexity": 0,
   // Require return statements to either always or never specify values
-  "consistent-return": 2,
+  "consistent-return": 1,
   // Specify curly brace conventions for all control statements
-  "curly": [2, "all"],
+  "curly": [1, "all"],
   // Require default case in switch statements (off by default)
   "default-case": 0,
   // Encourages use of dot notation whenever possible
-  "dot-notation": [2, { allowKeywords: true }],
+  "dot-notation": [1, { allowKeywords: true }],
   // Enforces consistent newlines before or after dots (off by default)
-  "dot-location": [2, "property"],
+  "dot-location": [1, "property"],
   // Require the use of === and !==
-  "eqeqeq": [2, "allow-null"],
+  "eqeqeq": [1, "allow-null"],
   // Make sure for-in loops have an if statement (off by default)
-  "guard-for-in": 2,
+  "guard-for-in": 1,
   // Disallow the use of alert, confirm, and prompt
-  "no-alert": 2,
+  "no-alert": 1,
   // Disallow use of arguments.caller or arguments.callee
   "no-caller": 2,
   // Disallow division operators explicitly at beginning of regular expression (off by default)
-  "no-div-regex": 2,
+  "no-div-regex": 1,
   // Disallow else after a return in an if (off by default)
   "no-else-return": 0,
   // Disallow use of labels for anything other than loops and switches
@@ -36,15 +36,15 @@ module.exports = {
   // Disallow use of eval()
   "no-eval": 2,
   // Disallow adding to native types
-  "no-extend-native": 2,
+  "no-extend-native": 1,
   // Disallow unnecessary function binding
-  "no-extra-bind": 2,
+  "no-extra-bind": 1,
   // Disallow fallthrough of case statements
-  "no-fallthrough": 2,
+  "no-fallthrough": 1,
   // Disallow the use of leading or trailing decimal points in numeric literals (off by default)
-  "no-floating-decimal": 2,
+  "no-floating-decimal": 1,
   // Disallow the type conversions with shorter notations
-  "no-implicit-coercion": 2,
+  "no-implicit-coercion": 1,
   // Disallow use of eval()-like methods
   "no-implied-eval": 2,
   // Disallow this keywords outside of classes or class-like objects
@@ -54,11 +54,11 @@ module.exports = {
   // Disallow use of labeled statements
   "no-labels": 2,
   // Disallow unnecessary nested blocks
-  "no-lone-blocks": 2,
+  "no-lone-blocks": 1,
   // Disallow creation of functions within loops
-  "no-loop-func": 2,
+  "no-loop-func": 1,
   // Disallow use of multiple spaces
-  "no-multi-spaces": 2,
+  "no-multi-spaces": 1,
   // Disallow use of multiline strings
   "no-multi-str": 0,
   // Disallow reassignments of native objects
@@ -66,42 +66,42 @@ module.exports = {
   // Disallow use of new operator for Function object
   "no-new-func": 2,
   // Disallows creating new instances of String, Number, and Boolean
-  "no-new-wrappers": 2,
+  "no-new-wrappers": 1,
   // Disallow use of new operator when not part of the assignment or comparison
-  "no-new": 2,
+  "no-new": 1,
   // Disallow use of octal escape sequences in string literals,
   // such as var foo = "Copyright \251";
-  "no-octal-escape": 2,
+  "no-octal-escape": 1,
   // Disallow use of octal literals
-  "no-octal": 2,
+  "no-octal": 1,
   // Allow reassignment of function parameters (off by default)
   "no-param-reassign": 0,
   // Disallow use of process.env (off by default)
-  "no-process-env": 2,
+  "no-process-env": 1,
   // Disallow usage of __proto__ property
   "no-proto": 2,
   // Disallow declaring the same variable more than once
-  "no-redeclare": 2,
+  "no-redeclare": 1,
   // Disallow use of assignment in return statement
-  "no-return-assign": 2,
+  "no-return-assign": 1,
   // Disallow use of javascript: urls.,
   "no-script-url": 0,
   // Disallow comparisons where both sides are exactly the same (off by default)
   "no-self-compare": 2,
   // Disallow use of comma operator
-  "no-sequences": 2,
+  "no-sequences": 1,
   // Restrict what can be thrown as an exception (off by default)
-  "no-throw-literal": 2,
+  "no-throw-literal": 1,
   // Allow usage of expressions in statement position
-  "no-unused-expressions": 2,
+  "no-unused-expressions": 1,
   // Disallow unnecessary .call() and .apply()
-  "no-useless-call": 2,
+  "no-useless-call": 1,
   // Disallow unnecessary concatenation of literals or template literals
-  "no-useless-concat": 2,
+  "no-useless-concat": 1,
   // Disallow use of void operator (off by default)
-  "no-void": 2,
+  "no-void": 1,
   // Disallow usage of configurable warning terms in comments
-  "no-warning-comments": 2,
+  "no-warning-comments": 1,
   // Disallow use of the with statement
   "no-with": 2,
   // Require use of the second argument for parseInt() (off by default)
@@ -109,7 +109,7 @@ module.exports = {
   // Requires to declare all vars on top of their containing scope (off by default)
   "vars-on-top": 0,
   // Require immediate function invocation to be wrapped in parentheses (off by default)
-  "wrap-iife": [2, "inside"],
+  "wrap-iife": [1, "inside"],
   // Require or disallow Yoda conditions
-  "yoda": [2, "never"]
+  "yoda": [1, "never"]
 }

--- a/rules/ecmascript-6.js
+++ b/rules/ecmascript-6.js
@@ -2,35 +2,35 @@
 
 module.exports = {
   // Require parens in arrow function arguments
-  "arrow-parens": [1, "always"],
+  'arrow-parens': [1, 'always'],
   // Require space before/after arrow function's arrow
-  "arrow-spacing": [1, {before: true, after: true}],
+  'arrow-spacing': [1, {before: true, after: true}],
   // Verify super() callings in constructors (off by default)
-  "constructor-super": 2,
+  'constructor-super': 2,
   // Enforce the spacing around the * in generator functions (off by default)
-  "generator-star-spacing": [1, "after"],
+  'generator-star-spacing': [1, 'after'],
   // Disallow modifying variables of class declarations
-  "no-class-assign": 1,
+  'no-class-assign': 1,
   // Disallow modifying variables that are declared using const
-  "no-const-assign": 2,
+  'no-const-assign': 2,
   // Disallow duplicate name in class members
-  "no-dupe-class-members": 2,
+  'no-dupe-class-members': 2,
   // Disallow to use this/super before super() calling in constructors. (off by default)
-  "no-this-before-super": 2,
+  'no-this-before-super': 2,
   // Require let or const instead of var (off by default)
-  "no-var": 2,
+  'no-var': 2,
   // Require method and property shorthand syntax for object literals (off by default)
-  "object-shorthand": [1, "always"],
+  'object-shorthand': [1, 'always'],
   // Suggest using arrow functions as callbacks
-  "prefer-arrow-callback": 2,
+  'prefer-arrow-callback': 2,
   // Suggest using of const declaration for variables that are never modified after declared (off by default)
-  "prefer-const": 0,
+  'prefer-const': 0,
   // Suggest using the spread operator instead of .apply()
-  "prefer-spread": 1,
+  'prefer-spread': 1,
   // Suggest using Reflect methods where applicable
-  "prefer-reflect": 0,
+  'prefer-reflect': 0,
   // Suggest using template literals instead of strings concatenation
-  "prefer-template": 1,
+  'prefer-template': 1,
   // Disallow generator functions that do not have yield
-  "require-yield": 2
+  'require-yield': 2,
 };

--- a/rules/ecmascript-6.js
+++ b/rules/ecmascript-6.js
@@ -18,11 +18,11 @@ module.exports = {
   // Disallow to use this/super before super() calling in constructors. (off by default)
   "no-this-before-super": 2,
   // Require let or const instead of var (off by default)
-  "no-var": 1,
+  "no-var": 2,
   // Require method and property shorthand syntax for object literals (off by default)
   "object-shorthand": [1, "always"],
   // Suggest using arrow functions as callbacks
-  "prefer-arrow-callback": 1,
+  "prefer-arrow-callback": 2,
   // Suggest using of const declaration for variables that are never modified after declared (off by default)
   "prefer-const": 0,
   // Suggest using the spread operator instead of .apply()

--- a/rules/ecmascript-6.js
+++ b/rules/ecmascript-6.js
@@ -26,7 +26,7 @@ module.exports = {
   // Suggest using of const declaration for variables that are never modified after declared (off by default)
   'prefer-const': 0,
   // Suggest using the spread operator instead of .apply()
-  'prefer-spread': 1,
+  'prefer-spread': 2,
   // Suggest using Reflect methods where applicable
   'prefer-reflect': 0,
   // Suggest using template literals instead of strings concatenation

--- a/rules/ecmascript-6.js
+++ b/rules/ecmascript-6.js
@@ -2,15 +2,15 @@
 
 module.exports = {
   // Require parens in arrow function arguments
-  "arrow-parens": [2, "always"],
+  "arrow-parens": [1, "always"],
   // Require space before/after arrow function's arrow
-  "arrow-spacing": [2, {before: true, after: true}],
+  "arrow-spacing": [1, {before: true, after: true}],
   // Verify super() callings in constructors (off by default)
   "constructor-super": 2,
   // Enforce the spacing around the * in generator functions (off by default)
-  "generator-star-spacing": [2, "after"],
+  "generator-star-spacing": [1, "after"],
   // Disallow modifying variables of class declarations
-  "no-class-assign": 2,
+  "no-class-assign": 1,
   // Disallow modifying variables that are declared using const
   "no-const-assign": 2,
   // Disallow duplicate name in class members
@@ -18,19 +18,19 @@ module.exports = {
   // Disallow to use this/super before super() calling in constructors. (off by default)
   "no-this-before-super": 2,
   // Require let or const instead of var (off by default)
-  "no-var": 2,
+  "no-var": 1,
   // Require method and property shorthand syntax for object literals (off by default)
-  "object-shorthand": [2, "always"],
+  "object-shorthand": [1, "always"],
   // Suggest using arrow functions as callbacks
-  "prefer-arrow-callback": 2,
+  "prefer-arrow-callback": 1,
   // Suggest using of const declaration for variables that are never modified after declared (off by default)
   "prefer-const": 0,
   // Suggest using the spread operator instead of .apply()
-  "prefer-spread": 2,
+  "prefer-spread": 1,
   // Suggest using Reflect methods where applicable
   "prefer-reflect": 0,
   // Suggest using template literals instead of strings concatenation
-  "prefer-template": 2,
+  "prefer-template": 1,
   // Disallow generator functions that do not have yield
   "require-yield": 2
 };

--- a/rules/legacy.js
+++ b/rules/legacy.js
@@ -2,15 +2,15 @@
 
 module.exports = {
   // Specify the maximum depth that blocks can be nested (off by default)
-  "max-depth": 0,
+  'max-depth': 0,
   // Specify the maximum length of a line in your program (off by default)
-  "max-len": 0,
+  'max-len': 0,
   // Limits the number of parameters that can be used in the function declaration. (off by default)
-  "max-params": [1, 10],
+  'max-params': [1, 10],
   // Specify the maximum number of statement allowed in a function (off by default)
-  "max-statements": 0,
+  'max-statements': 0,
   // Disallow use of bitwise operators (off by default)
-  "no-bitwise": 0,
+  'no-bitwise': 0,
   // Disallow use of unary operators, ++ and -- (off by default)
-  "no-plusplus": 0
+  'no-plusplus': 0,
 };

--- a/rules/legacy.js
+++ b/rules/legacy.js
@@ -6,7 +6,7 @@ module.exports = {
   // Specify the maximum length of a line in your program (off by default)
   "max-len": 0,
   // Limits the number of parameters that can be used in the function declaration. (off by default)
-  "max-params": [2, 10],
+  "max-params": [1, 10],
   // Specify the maximum number of statement allowed in a function (off by default)
   "max-statements": 0,
   // Disallow use of bitwise operators (off by default)

--- a/rules/node.js
+++ b/rules/node.js
@@ -2,21 +2,21 @@
 
 module.exports = {
   // enforce return after a callback
-  "callback-return": [1, ["callback", "cb", "next"]],
+  'callback-return': [1, ['callback', 'cb', 'next']],
   // disallow require() outside of the top-level module scope
-  "global-require": 0,
+  'global-require': 0,
   // Enforces error handling in callbacks (off by default) (on by default in the node environment)
-  "handle-callback-err": [1, "^.*(e|E)rr(or)?$"],
+  'handle-callback-err': [1, '^.*(e|E)rr(or)?$'],
   // Disallow mixing regular variable and require declarations (off by default) (on by default in the node environment)
-  "no-mixed-requires": 0,
+  'no-mixed-requires': 0,
   // Disallow use of new operator with the require function (off by default) (on by default in the node environment)
-  "no-new-require": 1,
+  'no-new-require': 1,
   // Disallow string concatenation with __dirname and __filename (off by default) (on by default in the node environment)
-  "no-path-concat": 1,
+  'no-path-concat': 1,
   // Disallow process.exit() (on by default in the node environment)
-  "no-process-exit": 1,
+  'no-process-exit': 1,
   // Restrict usage of specified node modules (off by default)
-  "no-restricted-modules": 0,
+  'no-restricted-modules': 0,
   // Disallow use of synchronous methods (off by default)
-  "no-sync": 1
+  'no-sync': 1,
 };

--- a/rules/node.js
+++ b/rules/node.js
@@ -2,21 +2,21 @@
 
 module.exports = {
   // enforce return after a callback
-  "callback-return": [2, ["callback", "cb", "next"]],
+  "callback-return": [1, ["callback", "cb", "next"]],
   // disallow require() outside of the top-level module scope
   "global-require": 0,
   // Enforces error handling in callbacks (off by default) (on by default in the node environment)
-  "handle-callback-err": [2, "^.*(e|E)rr(or)?$"],
+  "handle-callback-err": [1, "^.*(e|E)rr(or)?$"],
   // Disallow mixing regular variable and require declarations (off by default) (on by default in the node environment)
   "no-mixed-requires": 0,
   // Disallow use of new operator with the require function (off by default) (on by default in the node environment)
-  "no-new-require": 2,
+  "no-new-require": 1,
   // Disallow string concatenation with __dirname and __filename (off by default) (on by default in the node environment)
-  "no-path-concat": 2,
+  "no-path-concat": 1,
   // Disallow process.exit() (on by default in the node environment)
-  "no-process-exit": 2,
+  "no-process-exit": 1,
   // Restrict usage of specified node modules (off by default)
   "no-restricted-modules": 0,
   // Disallow use of synchronous methods (off by default)
-  "no-sync": 2
+  "no-sync": 1
 };

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -2,13 +2,13 @@
 
 module.exports = {
   // Disallow or enforce trailing commas
-  "comma-dangle": [2, "always-multiline"],
+  "comma-dangle": [1, "always-multiline"],
   // Disallow assignment in conditional expressions
   "no-cond-assign": 2,
   // Disallow use of console (off by default in the node environment)
   "no-console": 1,
   // Disallow use of constant expressions in conditions
-  "no-constant-condition": 2,
+  "no-constant-condition": 1,
   // Disallow control characters in regular expressions
   "no-control-regex": 2,
   // Disallow use of debugger
@@ -22,31 +22,31 @@ module.exports = {
   // Disallow the use of empty character classes in regular expressions
   "no-empty-character-class": 2,
   // Disallow empty statements
-  "no-empty": 2,
+  "no-empty": 1,
   // Disallow assigning to the exception in a catch block
   "no-ex-assign": 2,
   // Disallow double-negation boolean casts in a boolean context
-  "no-extra-boolean-cast": 0,
+  "no-extra-boolean-cast": 1,
   // Disallow unnecessary parentheses (off by default)
   "no-extra-parens": 0,
   // Disallow unnecessary semicolons
-  "no-extra-semi": 2,
+  "no-extra-semi": 1,
   // Disallow overwriting functions written as function declarations
-  "no-func-assign": 2,
+  "no-func-assign": 1,
   // Disallow function or variable declarations in nested blocks
-  "no-inner-declarations": 2,
+  "no-inner-declarations": 1,
   // Disallow invalid regular expression strings in the RegExp constructor
   "no-invalid-regexp": 2,
   // Disallow irregular whitespace outside of strings and comments
-  "no-irregular-whitespace": 2,
+  "no-irregular-whitespace": 1,
   // Disallow negation of the left operand of an in expression
-  "no-negated-in-lhs": 2,
+  "no-negated-in-lhs": 1,
   // Disallow the use of object properties of the global object (Math and JSON) as functions
   "no-obj-calls": 2,
   // Disallow multiple spaces in a regular expression literal
-  "no-regex-spaces": 2,
+  "no-regex-spaces": 1,
   // Disallow sparse arrays
-  "no-sparse-arrays": 2,
+  "no-sparse-arrays": 1,
   // Disallow unreachable statements after a return, throw, continue, or break statement
   "no-unreachable": 2,
   // Disallow comparisons with the value NaN
@@ -56,5 +56,5 @@ module.exports = {
   // Ensure that the results of typeof are compared against a valid string
   "valid-typeof": 2,
   // Avoid code that looks like two expressions but is actually one (off by default)
-  "no-unexpected-multiline": 2
+  "no-unexpected-multiline": 1
 };

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -2,59 +2,59 @@
 
 module.exports = {
   // Disallow or enforce trailing commas
-  "comma-dangle": [1, "always-multiline"],
+  'comma-dangle': [1, 'always-multiline'],
   // Disallow assignment in conditional expressions
-  "no-cond-assign": 2,
+  'no-cond-assign': 2,
   // Disallow use of console (off by default in the node environment)
-  "no-console": 1,
+  'no-console': 1,
   // Disallow use of constant expressions in conditions
-  "no-constant-condition": 1,
+  'no-constant-condition': 1,
   // Disallow control characters in regular expressions
-  "no-control-regex": 2,
+  'no-control-regex': 2,
   // Disallow use of debugger
-  "no-debugger": 1,
+  'no-debugger': 1,
   // Disallow duplicate arguments in functions
-  "no-dupe-args": 2,
+  'no-dupe-args': 2,
   // Disallow duplicate keys when creating object literals
-  "no-dupe-keys": 2,
+  'no-dupe-keys': 2,
   // Disallow a duplicate case label.
-  "no-duplicate-case": 2,
+  'no-duplicate-case': 2,
   // Disallow the use of empty character classes in regular expressions
-  "no-empty-character-class": 2,
+  'no-empty-character-class': 2,
   // Disallow empty statements
-  "no-empty": 1,
+  'no-empty': 1,
   // Disallow assigning to the exception in a catch block
-  "no-ex-assign": 2,
+  'no-ex-assign': 2,
   // Disallow double-negation boolean casts in a boolean context
-  "no-extra-boolean-cast": 1,
+  'no-extra-boolean-cast': 1,
   // Disallow unnecessary parentheses (off by default)
-  "no-extra-parens": 0,
+  'no-extra-parens': 0,
   // Disallow unnecessary semicolons
-  "no-extra-semi": 1,
+  'no-extra-semi': 1,
   // Disallow overwriting functions written as function declarations
-  "no-func-assign": 1,
+  'no-func-assign': 1,
   // Disallow function or variable declarations in nested blocks
-  "no-inner-declarations": 1,
+  'no-inner-declarations': 1,
   // Disallow invalid regular expression strings in the RegExp constructor
-  "no-invalid-regexp": 2,
+  'no-invalid-regexp': 2,
   // Disallow irregular whitespace outside of strings and comments
-  "no-irregular-whitespace": 1,
+  'no-irregular-whitespace': 1,
   // Disallow negation of the left operand of an in expression
-  "no-negated-in-lhs": 1,
+  'no-negated-in-lhs': 1,
   // Disallow the use of object properties of the global object (Math and JSON) as functions
-  "no-obj-calls": 2,
+  'no-obj-calls': 2,
   // Disallow multiple spaces in a regular expression literal
-  "no-regex-spaces": 1,
+  'no-regex-spaces': 1,
   // Disallow sparse arrays
-  "no-sparse-arrays": 1,
+  'no-sparse-arrays': 1,
   // Disallow unreachable statements after a return, throw, continue, or break statement
-  "no-unreachable": 2,
+  'no-unreachable': 2,
   // Disallow comparisons with the value NaN
-  "use-isnan": 2,
+  'use-isnan': 2,
   // Ensure JSDoc comments are valid (off by default)
-  "valid-jsdoc": 0,
+  'valid-jsdoc': 0,
   // Ensure that the results of typeof are compared against a valid string
-  "valid-typeof": 2,
+  'valid-typeof': 2,
   // Avoid code that looks like two expressions but is actually one (off by default)
-  "no-unexpected-multiline": 1
+  'no-unexpected-multiline': 1,
 };

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,14 +1,14 @@
 module.exports = {
   // Prevent missing displayName in a React component definition
-  "react/display-name": [2, { acceptTranspilerName: true }],
+  "react/display-name": [1, { acceptTranspilerName: true }],
   // Enforce boolean attributes notation in JSX
-  "react/jsx-boolean-value": 2,
+  "react/jsx-boolean-value": 1,
   // Validate closing bracket location in JSX
-  "react/jsx-closing-bracket-location": [2, { location: "tag-aligned" }],
+  "react/jsx-closing-bracket-location": [1, { location: "tag-aligned" }],
   // Enforce or disallow spaces inside of curly braces in JSX attributes
-  "react/jsx-curly-spacing": [2, "never", { allowMultiline: true }],
+  "react/jsx-curly-spacing": [1, "never", { allowMultiline: true }],
   // Validate props indentation in JSX
-  "react/jsx-indent-props": [2, 2],
+  "react/jsx-indent-props": [1, 2],
   // Limit maximum of props on a single line in JSX
   "react/jsx-max-props-per-line": 0,
   // Prevent duplicate props in JSX
@@ -22,11 +22,11 @@ module.exports = {
   // Enforce props alphabetical sorting
   "react/jsx-sort-props": 0,
   // Prevent React to be incorrectly marked as unused
-  "react/jsx-uses-react": 1,
+  "react/jsx-uses-react": 2,
   // Prevent variables used in JSX to be incorrectly marked as unused
   "react/jsx-uses-vars": 2,
   // Prevent usage of dangerous JSX properties
-  "react/no-danger": 2,
+  "react/no-danger": 1,
   // Prevent usage of setState in componentDidMount
   "react/no-did-mount-set-state": 2,
   // Prevent usage of setState in componentDidUpdate
@@ -38,16 +38,16 @@ module.exports = {
   // Prevent usage of unknown DOM property
   "react/no-unknown-property": 0,
   // Prevent missing props validation in a React component definition
-  "react/prop-types": 2,
+  "react/prop-types": 1,
   // Prevent missing React when using JSX
   "react/react-in-jsx-scope": 2,
   // Restrict file extensions that may be required
   "react/require-extension": [2, { extensions: [".js"] }],
   // Prevent extra closing tags for components without children
-  "react/self-closing-comp": 2,
+  "react/self-closing-comp": 1,
   // Enforce component methods order
   "react/sort-comp": [
-    2,
+    1,
     {
       order: [
         "statics",
@@ -59,5 +59,5 @@ module.exports = {
     }
   ],
   // Prevent missing parentheses around multilines JSX
-  "react/wrap-multilines": 2
+  "react/wrap-multilines": 1
 }

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,63 +1,63 @@
 module.exports = {
   // Prevent missing displayName in a React component definition
-  "react/display-name": [1, { acceptTranspilerName: true }],
+  'react/display-name': [1, {acceptTranspilerName: true}],
   // Enforce boolean attributes notation in JSX
-  "react/jsx-boolean-value": 1,
+  'react/jsx-boolean-value': 1,
   // Validate closing bracket location in JSX
-  "react/jsx-closing-bracket-location": [1, { location: "tag-aligned" }],
+  'react/jsx-closing-bracket-location': [1, {location: 'tag-aligned'}],
   // Enforce or disallow spaces inside of curly braces in JSX attributes
-  "react/jsx-curly-spacing": [1, "never", { allowMultiline: true }],
+  'react/jsx-curly-spacing': [1, 'never', {allowMultiline: true}],
   // Validate props indentation in JSX
-  "react/jsx-indent-props": [1, 2],
+  'react/jsx-indent-props': [1, 2],
   // Limit maximum of props on a single line in JSX
-  "react/jsx-max-props-per-line": 0,
+  'react/jsx-max-props-per-line': 0,
   // Prevent duplicate props in JSX
-  "react/jsx-no-duplicate-props": 2,
+  'react/jsx-no-duplicate-props': 2,
   // Prevent usage of unwrapped JSX strings
-  "react/jsx-no-literals": 0,
+  'react/jsx-no-literals': 0,
   // Disallow undeclared variables in JSX
-  "react/jsx-no-undef": 2,
+  'react/jsx-no-undef': 2,
   // Enforce propTypes declarations alphabetical sorting
-  "react/jsx-sort-prop-types": 0,
+  'react/jsx-sort-prop-types': 0,
   // Enforce props alphabetical sorting
-  "react/jsx-sort-props": 0,
+  'react/jsx-sort-props': 0,
   // Prevent React to be incorrectly marked as unused
-  "react/jsx-uses-react": 2,
+  'react/jsx-uses-react': 2,
   // Prevent variables used in JSX to be incorrectly marked as unused
-  "react/jsx-uses-vars": 2,
+  'react/jsx-uses-vars': 2,
   // Prevent usage of dangerous JSX properties
-  "react/no-danger": 1,
+  'react/no-danger': 1,
   // Prevent usage of setState in componentDidMount
-  "react/no-did-mount-set-state": 2,
+  'react/no-did-mount-set-state': 2,
   // Prevent usage of setState in componentDidUpdate
-  "react/no-did-update-set-state": 2,
+  'react/no-did-update-set-state': 2,
   // Prevent multiple component definition per file
-  "react/no-multi-comp": 0,
+  'react/no-multi-comp': 0,
   // Prevent usage of setState
-  "react/no-set-state": 0,
+  'react/no-set-state': 0,
   // Prevent usage of unknown DOM property
-  "react/no-unknown-property": 0,
+  'react/no-unknown-property': 0,
   // Prevent missing props validation in a React component definition
-  "react/prop-types": 1,
+  'react/prop-types': 1,
   // Prevent missing React when using JSX
-  "react/react-in-jsx-scope": 2,
+  'react/react-in-jsx-scope': 2,
   // Restrict file extensions that may be required
-  "react/require-extension": [2, { extensions: [".js"] }],
+  'react/require-extension': [2, {extensions: ['.js']}],
   // Prevent extra closing tags for components without children
-  "react/self-closing-comp": 1,
+  'react/self-closing-comp': 1,
   // Enforce component methods order
-  "react/sort-comp": [
+  'react/sort-comp': [
     1,
     {
       order: [
-        "statics",
-        "constructor",
-        "lifecycle",
-        "everything-else",
-        "render"
-      ]
-    }
+        'statics',
+        'constructor',
+        'lifecycle',
+        'everything-else',
+        'render',
+      ],
+    },
   ],
   // Prevent missing parentheses around multilines JSX
-  "react/wrap-multilines": 1
-}
+  'react/wrap-multilines': 1,
+};

--- a/rules/shopify.js
+++ b/rules/shopify.js
@@ -1,5 +1,6 @@
 module.exports = {
   // Requires (or disallows) @flow declarations be present at the top of each file.
-  "shopify/require-flow": [1, "always"],
-  "shopify/binary-assignment-parens": [1, "always"],
+  'shopify/require-flow': [1, 'always'],
+  // Requires (or disallows) assignments of binary, boolean-producing expressions to be wrapped in parentheses.
+  'shopify/binary-assignment-parens': [1, 'always'],
 };

--- a/rules/shopify.js
+++ b/rules/shopify.js
@@ -1,5 +1,5 @@
 module.exports = {
   // Requires (or disallows) @flow declarations be present at the top of each file.
-  "shopify/require-flow": [2, "always"],
-  "shopify/binary-assignment-parens": [2, "always"],
+  "shopify/require-flow": [1, "always"],
+  "shopify/binary-assignment-parens": [1, "always"],
 };

--- a/rules/strict-mode.js
+++ b/rules/strict-mode.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   // Controls location of Use Strict Directives
-  strict: [2, "never"]
+  strict: [2, 'never'],
 };

--- a/rules/strict-mode.js
+++ b/rules/strict-mode.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   // Controls location of Use Strict Directives
-  strict: [1, "never"]
+  strict: [2, "never"]
 };

--- a/rules/strict-mode.js
+++ b/rules/strict-mode.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   // Controls location of Use Strict Directives
-  strict: [2, "never"]
+  strict: [1, "never"]
 };

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -34,19 +34,19 @@ module.exports = {
   // Enforces spacing between keys and values in object literal properties
   "key-spacing": [1, { beforeColon: false, afterColon: true }],
   // Enforces empty lines around comments (off by default)
-  "lines-around-comment": [1, { beforeBlockComment: true }],
+  "lines-around-comment": [1, {beforeBlockComment: true}],
   // Disallow mixed "LF" and "CRLF" as linebreaks (off by default)
   "linebreak-style": 0,
   // Specify the maximum depth callbacks can be nested (off by default)
   "max-nested-callbacks": 0,
   // Require a capital letter for constructors
-  "new-cap": [1, { newIsCap: true }],
+  "new-cap": [2, {newIsCap: true}],
   // Disallow the omission of parentheses when invoking a constructor with no arguments
   "new-parens": 1,
   // Allow/disallow an empty newline after var statement (off by default)
   "newline-after-var": 0,
   // Disallow use of the Array constructor
-  "no-array-constructor": 1,
+  "no-array-constructor": 2,
   // Disallow use of the continue statement (off by default)
   "no-continue": 0,
   // Disallow comments inline after code (off by default)

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -2,113 +2,111 @@
 
 module.exports = {
   // Enforce spacing inside array brackets (off by default)
-  "array-bracket-spacing": [1, "never"],
+  'array-bracket-spacing': [1, 'never'],
   // Disallow or enforce spaces inside of single line blocks
-  "block-spacing": [1, "always"],
+  'block-spacing': [1, 'always'],
   // Enforce one true brace style (off by default)
-  "brace-style": [1, "1tbs", { allowSingleLine: true }],
+  'brace-style': [1, '1tbs', {allowSingleLine: true}],
   // Require camel case names
-  "camelcase": [1, { properties: "always" }],
+  'camelcase': [1, {properties: 'always'}],
   // Enforce spacing before and after comma
-  "comma-spacing": [1, { before: false, after: true }],
+  'comma-spacing': [1, {before: false, after: true}],
   // Enforce one true comma style (off by default)
-  "comma-style": [1, "last"],
+  'comma-style': [1, 'last'],
   // Require or disallow padding inside computed properties (off by default)
-  "computed-property-spacing": [1, "never"],
+  'computed-property-spacing': [1, 'never'],
   // Enforces consistent naming when capturing the current execution context (off by default)
-  "consistent-this": [1, "self"],
+  'consistent-this': [1, 'self'],
   // Enforce newline at the end of file, with no multiple empty lines
-  "eol-last": 1,
+  'eol-last': 1,
   // Don"t require function expressions to have a name (off by default)
-  "func-names": 0,
+  'func-names': 0,
   // Enforces use of function declarations or expressions (off by default)
-  "func-style": [1, "declaration"],
+  'func-style': [1, 'declaration'],
   // This option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-  "id-length": [1, {min: 2, properties: "always", exceptions: ["x", "y", "i", "j", "_"]}],
+  'id-length': [1, {min: 2, properties: 'always', exceptions: ['x', 'y', 'i', 'j', '_']}],
   // Require identifiers to match the provided regular expression
-  "id-match": 0,
+  'id-match': 0,
   // This option sets a specific tab width for your code (off by default)
-  "indent": [1, 2],
+  'indent': [1, 2],
   // Specify whether double or single quotes should be used in JSX attributes
-  "jsx-quotes": [1, "prefer-double"],
+  'jsx-quotes': [1, 'prefer-double'],
   // Enforces spacing between keys and values in object literal properties
-  "key-spacing": [1, { beforeColon: false, afterColon: true }],
+  'key-spacing': [1, {beforeColon: false, afterColon: true}],
   // Enforces empty lines around comments (off by default)
-  "lines-around-comment": [1, {beforeBlockComment: true}],
+  'lines-around-comment': [1, {beforeBlockComment: true}],
   // Disallow mixed "LF" and "CRLF" as linebreaks (off by default)
-  "linebreak-style": 0,
+  'linebreak-style': 0,
   // Specify the maximum depth callbacks can be nested (off by default)
-  "max-nested-callbacks": 0,
+  'max-nested-callbacks': 0,
   // Require a capital letter for constructors
-  "new-cap": [2, {newIsCap: true}],
+  'new-cap': [2, {newIsCap: true}],
   // Disallow the omission of parentheses when invoking a constructor with no arguments
-  "new-parens": 1,
+  'new-parens': 1,
   // Allow/disallow an empty newline after var statement (off by default)
-  "newline-after-var": 0,
+  'newline-after-var': 0,
   // Disallow use of the Array constructor
-  "no-array-constructor": 2,
+  'no-array-constructor': 2,
   // Disallow use of the continue statement (off by default)
-  "no-continue": 0,
+  'no-continue': 0,
   // Disallow comments inline after code (off by default)
-  "no-inline-comments": 0,
+  'no-inline-comments': 0,
   // Disallow if as the only statement in an else block (off by default)
-  "no-lonely-if": 1,
+  'no-lonely-if': 1,
   // Disallow mixed spaces and tabs for indentation
-  "no-mixed-spaces-and-tabs": 1,
+  'no-mixed-spaces-and-tabs': 1,
   // Disallow multiple empty lines (off by default)
-  "no-multiple-empty-lines": 1,
+  'no-multiple-empty-lines': 1,
   // Disallow nested ternary expressions (off by default)
-  "no-nested-ternary": 1,
+  'no-nested-ternary': 1,
   // Disallow use of the Object constructor
-  "no-new-object": 1,
+  'no-new-object': 1,
   // Disallow space between function identifier and application
-  "no-spaced-func": 1,
+  'no-spaced-func': 1,
   // Disallow the use of ternary operators (off by default)
-  "no-ternary": 0,
+  'no-ternary': 0,
   // Disallow trailing whitespace at the end of lines
-  "no-trailing-spaces": 1,
+  'no-trailing-spaces': 1,
   // Allow dangling underscores in identifiers
-  "no-underscore-dangle": 0,
+  'no-underscore-dangle': 0,
   // Disallow the use of Boolean literals in conditional expressions (off by default)
-  "no-unneeded-ternary": 1,
+  'no-unneeded-ternary': 1,
   // Require or disallow padding inside curly braces (off by default)
-  "object-curly-spacing": [1, "never"],
+  'object-curly-spacing': [1, 'never'],
   // Allow or disallow one variable declaration per function (off by default)
-  "one-var": [1, "never"],
+  'one-var': [1, 'never'],
   // Require assignment operator shorthand where possible or prohibit it entirely (off by default)
-  "operator-assignment": [1, "always"],
+  'operator-assignment': [1, 'always'],
   // Enforce operators to be placed before or after line breaks (off by default)
-  "operator-linebreak": [1, "after", { overrides: { "?": "before", ":": "before" } }],
+  'operator-linebreak': [1, 'after', {overrides: {'?': 'before', ':': 'before'}}],
   // Enforce padding within blocks (off by default)
-  "padded-blocks": 0,
+  'padded-blocks': 0,
   // Require quotes around object literal property names (off by default)
-  "quote-props": [1, "as-needed"],
+  'quote-props': [1, 'as-needed'],
   // Specify whether backticks, double or single quotes should be used
-  "quotes": [1, "single", "avoid-escape"],
+  'quotes': [1, 'single', 'avoid-escape'],
   // Enforce spacing before and after semicolons
-  "semi-spacing": [1, { before: false, after: true }],
+  'semi-spacing': [1, {before: false, after: true}],
   // Require or disallow use of semicolons instead of ASI
-  "semi": [1, "always"],
+  'semi': [1, 'always'],
   // Sort variables within the same declaration block (off by default)
-  "sort-vars": 0,
+  'sort-vars': 0,
   // Require a space after certain keywords (off by default)
-  "space-after-keywords": [1, "always"],
+  'space-after-keywords': [1, 'always'],
   // Require or disallow space before blocks (off by default)
-  "space-before-blocks": [1, "always"],
-  // Require a space before certain keywords
-  "space-after-keywords": [1, "always"],
+  'space-before-blocks': [1, 'always'],
   // Require or disallow space before function opening parenthesis (off by default)
-  "space-before-function-paren": [1, "never"],
+  'space-before-function-paren': [1, 'never'],
   // Require or disallow spaces inside parentheses (off by default)
-  "space-in-parens": [1, "never"],
+  'space-in-parens': [1, 'never'],
   // Require spaces around operators
-  "space-infix-ops": 1,
+  'space-infix-ops': 1,
   // Require a space after return, throw, and case
-  "space-return-throw-case": 1,
+  'space-return-throw-case': 1,
   // Require or disallow spaces before/after unary operators (words on by default, nonwords off by default)
-  "space-unary-ops": [1, { words: true, nonwords: false }],
+  'space-unary-ops': [1, {words: true, nonwords: false}],
   // Require or disallow a space immediately following the // or /* in a comment (off by default)
-  "spaced-comment": [1, "always"],
+  'spaced-comment': [1, 'always'],
   // Require regex literals to be wrapped in parentheses (off by default)
-  "wrap-regex": 0
+  'wrap-regex': 0,
 };

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -2,113 +2,113 @@
 
 module.exports = {
   // Enforce spacing inside array brackets (off by default)
-  "array-bracket-spacing": [2, "never"],
+  "array-bracket-spacing": [1, "never"],
   // Disallow or enforce spaces inside of single line blocks
-  "block-spacing": [2, "always"],
+  "block-spacing": [1, "always"],
   // Enforce one true brace style (off by default)
-  "brace-style": [2, "1tbs", { allowSingleLine: true }],
+  "brace-style": [1, "1tbs", { allowSingleLine: true }],
   // Require camel case names
-  "camelcase": [2, { properties: "always" }],
+  "camelcase": [1, { properties: "always" }],
   // Enforce spacing before and after comma
-  "comma-spacing": [2, { before: false, after: true }],
+  "comma-spacing": [1, { before: false, after: true }],
   // Enforce one true comma style (off by default)
-  "comma-style": [2, "last"],
+  "comma-style": [1, "last"],
   // Require or disallow padding inside computed properties (off by default)
-  "computed-property-spacing": [2, "never"],
+  "computed-property-spacing": [1, "never"],
   // Enforces consistent naming when capturing the current execution context (off by default)
-  "consistent-this": [2, "self"],
+  "consistent-this": [1, "self"],
   // Enforce newline at the end of file, with no multiple empty lines
-  "eol-last": 2,
+  "eol-last": 1,
   // Don"t require function expressions to have a name (off by default)
   "func-names": 0,
   // Enforces use of function declarations or expressions (off by default)
-  "func-style": [2, "declaration"],
+  "func-style": [1, "declaration"],
   // This option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-  "id-length": [2, {min: 2, properties: "always", exceptions: ["x", "y", "i", "j", "_"]}],
+  "id-length": [1, {min: 2, properties: "always", exceptions: ["x", "y", "i", "j", "_"]}],
   // Require identifiers to match the provided regular expression
   "id-match": 0,
   // This option sets a specific tab width for your code (off by default)
-  "indent": [2, 2],
+  "indent": [1, 2],
   // Specify whether double or single quotes should be used in JSX attributes
-  "jsx-quotes": [2, "prefer-double"],
+  "jsx-quotes": [1, "prefer-double"],
   // Enforces spacing between keys and values in object literal properties
-  "key-spacing": [2, { beforeColon: false, afterColon: true }],
+  "key-spacing": [1, { beforeColon: false, afterColon: true }],
   // Enforces empty lines around comments (off by default)
-  "lines-around-comment": [2, { beforeBlockComment: true }],
+  "lines-around-comment": [1, { beforeBlockComment: true }],
   // Disallow mixed "LF" and "CRLF" as linebreaks (off by default)
   "linebreak-style": 0,
   // Specify the maximum depth callbacks can be nested (off by default)
   "max-nested-callbacks": 0,
   // Require a capital letter for constructors
-  "new-cap": [2, { newIsCap: true }],
+  "new-cap": [1, { newIsCap: true }],
   // Disallow the omission of parentheses when invoking a constructor with no arguments
-  "new-parens": 2,
+  "new-parens": 1,
   // Allow/disallow an empty newline after var statement (off by default)
   "newline-after-var": 0,
   // Disallow use of the Array constructor
-  "no-array-constructor": 2,
+  "no-array-constructor": 1,
   // Disallow use of the continue statement (off by default)
   "no-continue": 0,
   // Disallow comments inline after code (off by default)
   "no-inline-comments": 0,
   // Disallow if as the only statement in an else block (off by default)
-  "no-lonely-if": 2,
+  "no-lonely-if": 1,
   // Disallow mixed spaces and tabs for indentation
-  "no-mixed-spaces-and-tabs": 2,
+  "no-mixed-spaces-and-tabs": 1,
   // Disallow multiple empty lines (off by default)
-  "no-multiple-empty-lines": 2,
+  "no-multiple-empty-lines": 1,
   // Disallow nested ternary expressions (off by default)
-  "no-nested-ternary": 2,
+  "no-nested-ternary": 1,
   // Disallow use of the Object constructor
-  "no-new-object": 2,
+  "no-new-object": 1,
   // Disallow space between function identifier and application
-  "no-spaced-func": 2,
+  "no-spaced-func": 1,
   // Disallow the use of ternary operators (off by default)
   "no-ternary": 0,
   // Disallow trailing whitespace at the end of lines
-  "no-trailing-spaces": 2,
+  "no-trailing-spaces": 1,
   // Allow dangling underscores in identifiers
   "no-underscore-dangle": 0,
   // Disallow the use of Boolean literals in conditional expressions (off by default)
-  "no-unneeded-ternary": 2,
+  "no-unneeded-ternary": 1,
   // Require or disallow padding inside curly braces (off by default)
-  "object-curly-spacing": [2, "never"],
+  "object-curly-spacing": [1, "never"],
   // Allow or disallow one variable declaration per function (off by default)
-  "one-var": [2, "never"],
+  "one-var": [1, "never"],
   // Require assignment operator shorthand where possible or prohibit it entirely (off by default)
-  "operator-assignment": [2, "always"],
+  "operator-assignment": [1, "always"],
   // Enforce operators to be placed before or after line breaks (off by default)
-  "operator-linebreak": [2, "after", { overrides: { "?": "before", ":": "before" } }],
+  "operator-linebreak": [1, "after", { overrides: { "?": "before", ":": "before" } }],
   // Enforce padding within blocks (off by default)
   "padded-blocks": 0,
   // Require quotes around object literal property names (off by default)
-  "quote-props": [2, "as-needed"],
+  "quote-props": [1, "as-needed"],
   // Specify whether backticks, double or single quotes should be used
-  "quotes": [2, "single", "avoid-escape"],
+  "quotes": [1, "single", "avoid-escape"],
   // Enforce spacing before and after semicolons
-  "semi-spacing": [2, { before: false, after: true }],
+  "semi-spacing": [1, { before: false, after: true }],
   // Require or disallow use of semicolons instead of ASI
-  "semi": [2, "always"],
+  "semi": [1, "always"],
   // Sort variables within the same declaration block (off by default)
   "sort-vars": 0,
   // Require a space after certain keywords (off by default)
-  "space-after-keywords": [2, "always"],
+  "space-after-keywords": [1, "always"],
   // Require or disallow space before blocks (off by default)
-  "space-before-blocks": [2, "always"],
+  "space-before-blocks": [1, "always"],
   // Require a space before certain keywords
-  "space-after-keywords": [2, "always"],
+  "space-after-keywords": [1, "always"],
   // Require or disallow space before function opening parenthesis (off by default)
-  "space-before-function-paren": [2, "never"],
+  "space-before-function-paren": [1, "never"],
   // Require or disallow spaces inside parentheses (off by default)
-  "space-in-parens": [2, "never"],
+  "space-in-parens": [1, "never"],
   // Require spaces around operators
-  "space-infix-ops": 2,
+  "space-infix-ops": 1,
   // Require a space after return, throw, and case
-  "space-return-throw-case": 2,
+  "space-return-throw-case": 1,
   // Require or disallow spaces before/after unary operators (words on by default, nonwords off by default)
-  "space-unary-ops": [2, { words: true, nonwords: false }],
+  "space-unary-ops": [1, { words: true, nonwords: false }],
   // Require or disallow a space immediately following the // or /* in a comment (off by default)
-  "spaced-comment": [2, "always"],
+  "spaced-comment": [1, "always"],
   // Require regex literals to be wrapped in parentheses (off by default)
   "wrap-regex": 0
 };

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -2,25 +2,25 @@
 
 module.exports = {
   // enforce or disallow variable initializations at definition
-  "init-declarations": [2, "always"],
+  "init-declarations": [1, "always"],
   // Disallow the catch clause parameter name being the same as a variable in the outer scope (off by default in the node environment)
-  "no-catch-shadow": 2,
+  "no-catch-shadow": 1,
   // Disallow deletion of variables
   "no-delete-var": 2,
   // Disallow labels that share a name with a variable
   "no-label-var": 2,
   // Disallow shadowing of names such as arguments
-  "no-shadow-restricted-names": 2,
+  "no-shadow-restricted-names": 1,
   // Disallow declaration of variables already declared in the outer scope
-  "no-shadow": 2,
+  "no-shadow": 1,
   // Disallow use of undefined when initializing variables
-  "no-undef-init": 2,
+  "no-undef-init": 1,
   // Disallow use of undeclared variables unless mentioned in a /*global */ block
   "no-undef": 2,
   // Disallow use of undefined variable (off by default)
   "no-undefined": 2,
   // Disallow declaration of variables that are not used in the code
-  "no-unused-vars": 2,
+  "no-unused-vars": 1,
   // Disallow use of variables before they are defined
-  "no-use-before-define": [2, "nofunc"]
+  "no-use-before-define": [1, "nofunc"]
 };

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -4,17 +4,17 @@ module.exports = {
   // enforce or disallow variable initializations at definition
   "init-declarations": [1, "always"],
   // Disallow the catch clause parameter name being the same as a variable in the outer scope (off by default in the node environment)
-  "no-catch-shadow": 1,
+  "no-catch-shadow": 2,
   // Disallow deletion of variables
   "no-delete-var": 2,
   // Disallow labels that share a name with a variable
   "no-label-var": 2,
   // Disallow shadowing of names such as arguments
-  "no-shadow-restricted-names": 1,
+  "no-shadow-restricted-names": 2,
   // Disallow declaration of variables already declared in the outer scope
-  "no-shadow": 1,
+  "no-shadow": 2,
   // Disallow use of undefined when initializing variables
-  "no-undef-init": 1,
+  "no-undef-init": 2,
   // Disallow use of undeclared variables unless mentioned in a /*global */ block
   "no-undef": 2,
   // Disallow use of undefined variable (off by default)
@@ -22,5 +22,5 @@ module.exports = {
   // Disallow declaration of variables that are not used in the code
   "no-unused-vars": 1,
   // Disallow use of variables before they are defined
-  "no-use-before-define": [1, "nofunc"]
+  "no-use-before-define": [2, "nofunc"]
 };

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -2,25 +2,25 @@
 
 module.exports = {
   // enforce or disallow variable initializations at definition
-  "init-declarations": [1, "always"],
+  'init-declarations': [1, 'always'],
   // Disallow the catch clause parameter name being the same as a variable in the outer scope (off by default in the node environment)
-  "no-catch-shadow": 2,
+  'no-catch-shadow': 2,
   // Disallow deletion of variables
-  "no-delete-var": 2,
+  'no-delete-var': 2,
   // Disallow labels that share a name with a variable
-  "no-label-var": 2,
+  'no-label-var': 2,
   // Disallow shadowing of names such as arguments
-  "no-shadow-restricted-names": 2,
+  'no-shadow-restricted-names': 2,
   // Disallow declaration of variables already declared in the outer scope
-  "no-shadow": 2,
+  'no-shadow': 2,
   // Disallow use of undefined when initializing variables
-  "no-undef-init": 2,
+  'no-undef-init': 2,
   // Disallow use of undeclared variables unless mentioned in a /*global */ block
-  "no-undef": 2,
+  'no-undef': 2,
   // Disallow use of undefined variable (off by default)
-  "no-undefined": 2,
+  'no-undefined': 2,
   // Disallow declaration of variables that are not used in the code
-  "no-unused-vars": 1,
+  'no-unused-vars': 1,
   // Disallow use of variables before they are defined
-  "no-use-before-define": [2, "nofunc"]
+  'no-use-before-define': [2, 'nofunc'],
 };


### PR DESCRIPTION
As discussed in Slack. I did my best to keep as errors the rules that either:

1. Represented obvious bugs that should be dealt with immediately, like duplicate keys, duplicate args, or variables used before they are defined, or

2. Represented such bad JS coding practices that I just can't change them to not be errors, like `eval`, `with`, or accessing non-standard properties like `__proto__` (technically a standard now, but an immediately deprecated one).

I'm happy to discuss any of the changed rules/ rules that were not changed to see where they should land.

cc/ @bouk @boourns 