### PR TITLE
Update ESLint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ For changes to existing rules, bump the major version. For addition of new rules
 
 ## Changelog
 
+### 5.7.0
+
+Updated ESLint to 1.8 and added the new rules.
+
 ### 5.6.1
 
 Fix non-prefixed React plugin rule.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install --save-dev eslint babel-eslint eslint-plugin-react eslint-plugin-sho
 npm install --save-dev eslint-config-shopify
 ```
 
-then, extend the React version of this configuration in your own `.eslintrc`:
+then, extend the React version of this configuration in your own `.eslintrc.json`:
 
 ```json
 {
@@ -67,7 +67,7 @@ For changes to existing rules, bump the major version. For addition of new rules
 
 ### 5.7.0
 
-Updated ESLint to 1.8 and added the new rules.
+Updated `eslint` dependency to 1.10 and `eslint-plugin-react` dependency to 3.11, and added the new rules introduced up that point.
 
 ### 5.6.1
 

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
   },
   "devDependencies": {
     "babel-eslint": "^4.1.2",
-    "eslint": "^1.8.0",
+    "eslint": "^1.10.0",
     "eslint-config-shopify": "file:.",
-    "eslint-plugin-react": "^3.6.0",
+    "eslint-plugin-react": "^3.11.0",
     "eslint-plugin-shopify": "^2.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=1.8.0",
-    "eslint-plugin-react": "^3.6.0",
+    "eslint": ">=1.10.0",
+    "eslint-plugin-react": "^3.11.0",
     "eslint-plugin-shopify": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-shopify": "^2.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=1.5.0",
+    "eslint": ">=1.8.0",
     "eslint-plugin-react": "^3.6.0",
     "eslint-plugin-shopify": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-shopify",
-  "version": "5.6.1",
+  "version": "5.7.0",
   "description": "Shopify's baseline ESLint config.",
   "main": "./es6/index.js",
   "repository": {
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^4.1.2",
-    "eslint": "^1.4.1",
+    "eslint": "^1.8.0",
     "eslint-config-shopify": "file:.",
     "eslint-plugin-react": "^3.6.0",
     "eslint-plugin-shopify": "^2.0.0"

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -31,6 +31,8 @@ module.exports = {
   'no-else-return': 0,
   // Disallow use of labels for anything other than loops and switches
   'no-empty-label': 2,
+  // Disallow use of empty destructuring patterns
+  'no-empty-pattern': 2,
   // Disallow comparisons to null without a type-checking operator (off by default)
   'no-eq-null': 0,
   // Disallow use of eval()
@@ -57,6 +59,8 @@ module.exports = {
   'no-lone-blocks': 1,
   // Disallow creation of functions within loops
   'no-loop-func': 2,
+  // Disallow the use of magic numbers
+  'no-magic-numbers': 0,
   // Disallow use of multiple spaces
   'no-multi-spaces': 1,
   // Disallow use of multiline strings

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -23,6 +23,8 @@ module.exports = {
   'guard-for-in': 1,
   // Disallow the use of alert, confirm, and prompt
   'no-alert': 1,
+  // disallow lexical declarations in case clauses
+  'no-case-declarations': 2,
   // Disallow use of arguments.caller or arguments.callee
   'no-caller': 2,
   // Disallow division operators explicitly at beginning of regular expression (off by default)

--- a/rules/ecmascript-6.js
+++ b/rules/ecmascript-6.js
@@ -1,6 +1,8 @@
 // see http://eslint.org/docs/rules/#ecmascript-6
 
 module.exports = {
+  // Require braces in arrow function body
+  'arrow-body-style': [2, 'as-needed'],
   // Require parens in arrow function arguments
   'arrow-parens': [1, 'always'],
   // Require space before/after arrow function's arrow
@@ -9,6 +11,8 @@ module.exports = {
   'constructor-super': 2,
   // Enforce the spacing around the * in generator functions (off by default)
   'generator-star-spacing': [1, 'after'],
+  // Disallow arrow functions where a condition is expected
+  'no-arrow-condition': 2,
   // Disallow modifying variables of class declarations
   'no-class-assign': 1,
   // Disallow modifying variables that are declared using const

--- a/rules/react.js
+++ b/rules/react.js
@@ -11,14 +11,20 @@ module.exports = {
   'react/jsx-curly-spacing': [1, 'never', {allowMultiline: true}],
   // Validate props indentation in JSX
   'react/jsx-indent-props': [1, 2],
+  // Validate JSX has key prop when in array or iterator
+  'react/jsx-key': 2,
   // Limit maximum of props on a single line in JSX
   'react/jsx-max-props-per-line': 0,
+  // Prevent usage of .bind() and arrow functions in JSX props
+  'jsx-no-bind': 0,
   // Prevent duplicate props in JSX
   'react/jsx-no-duplicate-props': 2,
   // Prevent usage of unwrapped JSX strings
   'react/jsx-no-literals': 0,
   // Disallow undeclared variables in JSX
   'react/jsx-no-undef': 2,
+  // Enforce PascalCase for user-defined JSX components
+  'react/jsx-pascal-case': 2,
   // Enforce propTypes declarations alphabetical sorting
   'react/jsx-sort-prop-types': 0,
   // Enforce props alphabetical sorting


### PR DESCRIPTION
Adds new rules that I could see up to v1.8.0 of ESLint. Once this is out, I will have to cut a new release of this + the plugin and update in Shopify Native.

cc/ @bouk @boourns 