### PR TITLE
Update React plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ For changes to existing rules, bump the major version. For addition of new rules
 
 ## Changelog
 
+### 5.8.0
+
+Updated `eslint-plugin-react` dependency to 3.14, and added the newly introduced rules.
+
 ### 5.7.1
 
 Removed `no-arrow-condition` for `ecmascript-6` that conflicted with `arrow-body-style` rule

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-eslint": "^4.1.2",
     "eslint": "^1.10.0",
     "eslint-config-shopify": "file:.",
-    "eslint-plugin-react": "^3.11.0",
+    "eslint-plugin-react": "^3.14.0",
     "eslint-plugin-shopify": "^2.0.0"
   },
   "peerDependencies": {

--- a/rules/react.js
+++ b/rules/react.js
@@ -11,6 +11,8 @@ module.exports = {
   'react/jsx-curly-spacing': [1, 'never', {allowMultiline: true}],
   // Validate props indentation in JSX
   'react/jsx-indent-props': [1, 2],
+  // Validate JSX indentation
+  'react/jsx-indent': [1, 2],
   // Validate JSX has key prop when in array or iterator
   'react/jsx-key': 2,
   // Limit maximum of props on a single line in JSX
@@ -35,16 +37,22 @@ module.exports = {
   'react/jsx-uses-vars': 2,
   // Prevent usage of dangerous JSX properties
   'react/no-danger': 1,
+  // Prevent usage of deprecated methods
+  'react/no-deprecated': 2,
   // Prevent usage of setState in componentDidMount
   'react/no-did-mount-set-state': 2,
   // Prevent usage of setState in componentDidUpdate
   'react/no-did-update-set-state': 2,
   // Prevent direct mutation of this.state
   'react/no-direct-mutation-state': 2,
+  // Prevent usage of isMounted
+  'react/no-is-mounted': 2,
   // Prevent multiple component definition per file
   'react/no-multi-comp': 0,
   // Prevent usage of setState
   'react/no-set-state': 0,
+  // Prevent using string references in ref attribute.
+  'react/no-string-refs': 1,
   // Prevent usage of unknown DOM property
   'react/no-unknown-property': 0,
   // Prevent missing props validation in a React component definition


### PR DESCRIPTION
This PR updates the config to include the new rules introduced in React 3.12–3.14. I think the config choices are pretty straightforward, with the exception of the `no-string-refs` — string refs are going away, but I imagine we use them in many places.

cc/ @bouk @jufashpfy @dan-menard 